### PR TITLE
Fix the disappearing-numbers bug

### DIFF
--- a/app/item/items.component.html
+++ b/app/item/items.component.html
@@ -27,10 +27,9 @@ class names available for styling your app at https://docs.nativescript.org/ui/t
 
     <RadListView [items]="itemsOnPage" class="list-group">
         <ng-template tkListItemTemplate let-item="item">
-            <GridLayout columns="*,auto" rows="auto">
-                <Label row="0" col="0" class="h3" 
-                    text='{{item.name + " - " + item.role}}'></Label>
-                <Label row="0" col="1" class="h3" text="{{item.id}}"></Label>  
+            <GridLayout columns="*, 30" rows="*">
+                <Label class="h3" text='{{item.name + " - " + item.role}}'></Label>
+                <Label col="1" class="h3" text="{{item.id}}" style="text-align: right"></Label>  
             </GridLayout>                
         </ng-template>
     </RadListView>


### PR DESCRIPTION
I *think* the bug is caused by view/template recycling; the numbers < 10 have very small seconds column widths. From 10 on they get wider to accommodate for the larger number. When you scroll in landscape those smaller views are probably recycled and used for showing larger numbers.

Easy fix: just give the second columns a fixed width that's large enough for any number.

Not saying this isn't an issue with NativeScript, but it is easy to work around.